### PR TITLE
Ask for 'All' SQS queue attributes along with the message-attributes

### DIFF
--- a/lib/toiler/actor/fetcher.rb
+++ b/lib/toiler/actor/fetcher.rb
@@ -73,7 +73,8 @@ module Toiler
 
       def poll_future
         Concurrent.future do
-          queue.receive_messages message_attribute_names: %w(All),
+          queue.receive_messages attribute_names: %w(All),
+                                 message_attribute_names: %w(All),
                                  wait_time_seconds: wait,
                                  max_number_of_messages: max_messages
         end


### PR DESCRIPTION
Need to pull the SQS attributes to calculate things like "message queue wait time". 

Is this ok to be hardcoded or does it make sense to add it as a user configuration option?

Reference Docs: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#receive_message-instance_method